### PR TITLE
11 add coverage ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+name: Generate coverage badges
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  generate-badges:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # setup go environment
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+  
+      - name: coverage
+        id: coverage
+        run: |
+          go mod download
+          go generate ./...
+          go test -coverpkg=./... -coverprofile=profile.cov ./...
+          sed -i '/cmd/d' profile.cov    # remove cmd package from coverage
+          total=$(go tool cover -func profile.cov | grep '^total:' | awk '{print $3}' | sed "s/%//")
+          rm profile.cov
+          echo "COVERAGE_VALUE=${total}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: sgaunet/gh-action-badge
+          path: gh-action-badge
+          ref: main
+          fetch-depth: 1
+
+      - name: Generate coverage badge
+        id: coverage-badge
+        uses: ./gh-action-badge/.github/actions/gh-action-coverage
+        with:
+          limit-coverage: "70"
+          badge-label: "coverage"
+          badge-filename: "coverage-badge.svg"
+          badge-value: "${COVERAGE_VALUE}"
+
+      - name: Print url of badge
+        run: |
+          echo "Badge URL: ${{ steps.coverage-badge.outputs.badge-url }}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
+[![GitHub release](https://img.shields.io/github/release/sgaunet/gini.svg)](https://github.com/sgaunet/gini/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sgaunet/gini)](https://goreportcard.com/report/github.com/sgaunet/gini)
+![GitHub Downloads](https://img.shields.io/github/downloads/sgaunet/gini/total)
+![Coverage](https://raw.githubusercontent.com/wiki/sgaunet/gini/coverage-badge.svg)
+[![coverage](https://github.com/sgaunet/gini/actions/workflows/coverage.yml/badge.svg)](https://github.com/sgaunet/gini/actions/workflows/coverage.yml)
+[![Snapshot Build](https://github.com/sgaunet/gini/actions/workflows/snapshot.yml/badge.svg)](https://github.com/sgaunet/gini/actions/workflows/snapshot.yml)
+[![Release Build](https://github.com/sgaunet/gini/actions/workflows/release.yml/badge.svg)](https://github.com/sgaunet/gini/actions/workflows/release.yml)
+[![License](https://img.shields.io/github/license/sgaunet/gini.svg)](LICENSE)
 
 # gini
 


### PR DESCRIPTION
- **feat: add GitHub Actions workflow to generate coverage badges**
  

- **chore: update README.md to include additional badges for downloads, coverage, and build status**
  